### PR TITLE
package: Update gnode to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "co-mocha": "^1.0.0",
     "duo": "^0.8.1",
-    "gnode": "0.0.8",
+    "gnode": "^0.1.1",
     "mocha": "^1.21.4"
   },
   "main": "index",


### PR DESCRIPTION
This patch allows the tests to be run on node 0.10.

Ref: TooTallNate/gnode#13
